### PR TITLE
[Feat] #34 로그인 기능 구현

### DIFF
--- a/NBCinema/NBCinema/App/Coordinator/AuthCoordinator.swift
+++ b/NBCinema/NBCinema/App/Coordinator/AuthCoordinator.swift
@@ -21,7 +21,7 @@ class AuthCoordinator: BaseCoordinator {
     
     /// 로그인 화면 표시
     private func showLogin() {
-        let authVC = LoginViewController()
+        let authVC = LoginViewController(viewModel: LoginViewModel())
         authVC.coordinator = self
         navigationController.setViewControllers([authVC], animated: false)
     }

--- a/NBCinema/NBCinema/Presentation/Auth/KeychainConstants.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/KeychainConstants.swift
@@ -1,0 +1,12 @@
+//
+//  KeychainConstants.swift
+//  NBCinema
+//
+//  Created by estelle on 7/18/25.
+//
+
+enum KeychainConstants {
+    static let service = "NBCinema"
+    static let emailAccount = "userEmail"
+    static let passwordAccount = "userPassword"
+}

--- a/NBCinema/NBCinema/Presentation/Auth/Login/LoginView.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/Login/LoginView.swift
@@ -63,9 +63,11 @@ class LoginView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - UI 구성
+    
     private func setupUI() {
         layer.insertSublayer(gradientLayer, at: 0)
-        //loginButton.isEnabled = false
+        loginButton.isEnabled = false
         
         [questionLabel, moveToSignUpButton].forEach {
             questionStackView.addArrangedSubview($0)

--- a/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewController.swift
@@ -10,28 +10,153 @@ import UIKit
 class LoginViewController: UIViewController {
     
     weak var coordinator: AuthCoordinator?
+    private let viewModel: LoginViewModel
     private let loginView = LoginView()
+    private var didTapLoginButton = false
+    
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.action(.loadUserData)     // 텍스트필드 자동 입력
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupDelegates()
         setupAction()
+        bindViewModel()
     }
     
     override func loadView() {
         view = loginView
     }
     
-    // 버튼에 이벤트 연결
+    // MARK: - Setup 메서드
+    
+    // 텍스트필드 delegate 연결
+    private func setupDelegates() {
+        loginView.emailInput.textField.delegate = self
+        loginView.passwordInput.textField.delegate = self
+    }
+    
+    // 텍스트필드 및 버튼에 이벤트 연결
     private func setupAction() {
+        loginView.emailInput.textField.addTarget(self, action: #selector(emailChanged), for: .editingChanged)
+        loginView.passwordInput.textField.addTarget(self, action: #selector(passwordChanged), for: .editingChanged)
         loginView.loginButton.addTarget(self, action: #selector(loginTapped), for: .touchUpInside)
         loginView.moveToSignUpButton.addTarget(self, action: #selector(moveToSignUpTapped), for: .touchUpInside)
     }
     
+    // ViewModel의 상태 바인딩
+    private func bindViewModel() {
+        viewModel.onStateChanged = { [weak self] state in
+            guard let self else { return }
+            self.loginView.emailInput.textField.text = state.email
+            self.loginView.passwordInput.textField.text = state.password
+            self.loginView.emailInput.setHidden(state.email.isEmpty)
+            self.loginView.passwordInput.setHidden(state.password.isEmpty)
+            self.loginView.emailInput.setError(state.emailError)
+            self.loginView.loginButton.isEnabled = state.isLoginEnabled
+            
+            if self.didTapLoginButton {
+                if state.isLoginSuccess {
+                    self.coordinator?.loginCompleted()
+                } else {
+                    self.showAlert()
+                }
+                self.didTapLoginButton = false
+            }
+            
+            updatePlaceholder(for: loginView.emailInput.textField)
+            updatePlaceholder(for: loginView.passwordInput.textField)
+        }
+    }
+    
+    // MARK: - Actions
+    
+    // 이메일 입력 변경 시 호출
+    @objc private func emailChanged(_ sender: UITextField) {
+        viewModel.action(.emailChanged(sender.text ?? ""))
+    }
+    
+    // 비밀번호 입력 변경 시 호출
+    @objc private func passwordChanged(_ sender: UITextField) {
+        viewModel.action(.passwordChanged(sender.text ?? ""))
+    }
+    
     @objc private func loginTapped() {
-        coordinator?.loginCompleted()
+        didTapLoginButton = true
+        viewModel.action(.login)
     }
     
     @objc private func moveToSignUpTapped() {
         coordinator?.showSignUp()
+    }
+    
+    // 로그인 실패 시 Alert
+    private func showAlert() {
+        let alert = UIAlertController(title: "실패", message: "아이디 또는 비밀번호가 틀립니다.", preferredStyle: .alert)
+        alert.addAction(.init(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension LoginViewController: UITextFieldDelegate {
+    
+    // 키보드 done 버튼 누를 때 다음 텍스트 필드로 이동
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if textField == loginView.emailInput.textField {
+            loginView.passwordInput.textField.becomeFirstResponder()
+        } else if textField == loginView.passwordInput.textField {
+            loginView.passwordInput.textField.resignFirstResponder()
+        }
+        return true
+    }
+    
+    // 텍스트 필드 포커스 진입 시 placeholder 위로 이동
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        updatePlaceholder(for: textField)
+    }
+    
+    // 텍스트 필드 포커스 종료 시 (빈 경우) placeholder 원래 위치로 복귀
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        updatePlaceholder(for: textField)
+    }
+    
+    // 텍스트필드와 placeholder 쌍을 반환
+    private func textFieldPlaceholderPair(for textField: UITextField) -> (UILabel, UITextField)? {
+        switch textField {
+        case loginView.emailInput.textField:
+            return (loginView.emailInput.placeholderLabel, loginView.emailInput.textField)
+        case loginView.passwordInput.textField:
+            return (loginView.passwordInput.placeholderLabel, loginView.passwordInput.textField)
+        default:
+            return nil
+        }
+    }
+    
+    private func updatePlaceholder(for textField: UITextField) {
+        guard let (placeholder, input) = textFieldPlaceholderPair(for: textField) else { return }
+        
+        let isEmpty = textField.text?.isEmpty ?? true
+        let shouldMoveUp = textField.isFirstResponder || !isEmpty
+        
+        UIView.animate(withDuration: 0.25) {
+            placeholder.snp.updateConstraints {
+                $0.centerY.equalTo(input).offset(shouldMoveUp ? -15 : 0)
+            }
+            placeholder.font = .systemFont(ofSize: shouldMoveUp ? 12 : 16)
+            placeholder.superview?.layoutIfNeeded()
+        }
     }
 }

--- a/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewController.swift
@@ -12,7 +12,7 @@ class LoginViewController: UIViewController {
     weak var coordinator: AuthCoordinator?
     private let viewModel: LoginViewModel
     private let loginView = LoginView()
-    private var didTapLoginButton = false
+    private var isLogin = false
     
     init(viewModel: LoginViewModel) {
         self.viewModel = viewModel
@@ -59,20 +59,20 @@ class LoginViewController: UIViewController {
     private func bindViewModel() {
         viewModel.onStateChanged = { [weak self] state in
             guard let self else { return }
-            self.loginView.emailInput.textField.text = state.email
-            self.loginView.passwordInput.textField.text = state.password
-            self.loginView.emailInput.setHidden(state.email.isEmpty)
-            self.loginView.passwordInput.setHidden(state.password.isEmpty)
-            self.loginView.emailInput.setError(state.emailError)
-            self.loginView.loginButton.isEnabled = state.isLoginEnabled
+            loginView.emailInput.textField.text = state.email
+            loginView.passwordInput.textField.text = state.password
+            loginView.emailInput.setHidden(state.email.isEmpty)
+            loginView.passwordInput.setHidden(state.password.isEmpty)
+            loginView.emailInput.setError(state.emailError)
+            loginView.loginButton.isEnabled = state.isLoginEnabled
             
-            if self.didTapLoginButton {
+            if isLogin {
                 if state.isLoginSuccess {
-                    self.coordinator?.loginCompleted()
+                    coordinator?.loginCompleted()
                 } else {
-                    self.showAlert()
+                    showAlert()
                 }
-                self.didTapLoginButton = false
+                isLogin = false
             }
             
             updatePlaceholder(for: loginView.emailInput.textField)
@@ -93,7 +93,7 @@ class LoginViewController: UIViewController {
     }
     
     @objc private func loginTapped() {
-        didTapLoginButton = true
+        isLogin = true
         viewModel.action(.login)
     }
     
@@ -103,7 +103,7 @@ class LoginViewController: UIViewController {
     
     // 로그인 실패 시 Alert
     private func showAlert() {
-        let alert = UIAlertController(title: "실패", message: "아이디 또는 비밀번호가 틀립니다.", preferredStyle: .alert)
+        let alert = UIAlertController(title: "실패", message: "이메일 또는 비밀번호가 틀립니다.", preferredStyle: .alert)
         alert.addAction(.init(title: "확인", style: .default))
         present(alert, animated: true)
     }
@@ -133,30 +133,26 @@ extension LoginViewController: UITextFieldDelegate {
         updatePlaceholder(for: textField)
     }
     
-    // 텍스트필드와 placeholder 쌍을 반환
-    private func textFieldPlaceholderPair(for textField: UITextField) -> (UILabel, UITextField)? {
+    // placeholder 반환
+    private func getPlaceholder(for textField: UITextField) -> UILabel? {
         switch textField {
         case loginView.emailInput.textField:
-            return (loginView.emailInput.placeholderLabel, loginView.emailInput.textField)
+            return loginView.emailInput.placeholderLabel
         case loginView.passwordInput.textField:
-            return (loginView.passwordInput.placeholderLabel, loginView.passwordInput.textField)
+            return loginView.passwordInput.placeholderLabel
         default:
             return nil
         }
     }
     
     private func updatePlaceholder(for textField: UITextField) {
-        guard let (placeholder, input) = textFieldPlaceholderPair(for: textField) else { return }
+        guard let placeholder = getPlaceholder(for: textField) else { return }
         
         let isEmpty = textField.text?.isEmpty ?? true
         let shouldMoveUp = textField.isFirstResponder || !isEmpty
         
         UIView.animate(withDuration: 0.25) {
-            placeholder.snp.updateConstraints {
-                $0.centerY.equalTo(input).offset(shouldMoveUp ? -15 : 0)
-            }
-            placeholder.font = .systemFont(ofSize: shouldMoveUp ? 12 : 16)
-            placeholder.superview?.layoutIfNeeded()
+            placeholder.transform = shouldMoveUp ? CGAffineTransform(translationX: -5, y: -15).scaledBy(x: 0.75, y: 0.75) : .identity
         }
     }
 }

--- a/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewModel.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewModel.swift
@@ -1,0 +1,83 @@
+//
+//  LoginViewModel.swift
+//  NBCinema
+//
+//  Created by estelle on 7/18/25.
+//
+
+import Foundation
+
+class LoginViewModel: ViewModelProtocol {
+    enum Action {
+        case loadUserData
+        case emailChanged(String)
+        case passwordChanged(String)
+        case login
+    }
+    
+    struct State {
+        var email: String = ""
+        var emailError: String?
+        
+        var password: String = ""
+        
+        var isLoginEnabled: Bool = false       // 로그인 버튼 활성화 여부
+        var isLoginSuccess: Bool = false       // 로그인 성공 여부
+    }
+    
+    private(set) var state: State = .init() {
+        didSet {
+            onStateChanged?(state)
+        }
+    }
+    
+    var onStateChanged: ((State) -> Void)?
+    private var userEmail = ""
+    private var userPassword = ""
+    
+    func action(_ action: Action) {
+        switch action {
+        case .loadUserData:
+            state.email = KeychainService.load(service: KeychainConstants.service, account: KeychainConstants.emailAccount) ?? ""
+            state.password = KeychainService.load(service: KeychainConstants.service, account: KeychainConstants.passwordAccount) ?? ""
+            userEmail = state.email
+            userPassword = state.password
+            
+        case .emailChanged(let email):
+            state.email = email
+            validateEmail()
+            
+        case .passwordChanged(let password):
+            state.password = password
+            
+        case .login:        // 키체인에 저장된 값과 입력값이 다를 경우 로그인 실패
+            state.isLoginSuccess = (userEmail == state.email && userPassword == state.password) ? KeychainService.save(service: KeychainConstants.service, account: KeychainConstants.emailAccount, value: state.email) && KeychainService.save(service: KeychainConstants.service, account: KeychainConstants.passwordAccount, value: state.password) : false
+            
+            if !state.isLoginSuccess {
+                state.email = ""
+                state.password = ""
+            }
+        }
+        
+        updateLoginEnabled()
+    }
+    
+    // 이메일 유효성 검사
+    private func validateEmail() {
+        if state.email.isEmpty {
+            state.emailError = "이메일을 입력해주세요."
+        } else if SignUpViewModel().isValidEmail(state.email) {
+            state.emailError = nil
+        } else {
+            state.emailError = "올바른 이메일 형식이 아닙니다."
+        }
+    }
+    
+    // 로그인 버튼 활성화 여부
+    private func updateLoginEnabled() {
+        state.isLoginEnabled =
+        state.emailError == nil &&
+        !state.password.isEmpty &&
+        !state.email.isEmpty
+    }
+}

--- a/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewModel.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/Login/LoginViewModel.swift
@@ -51,7 +51,18 @@ class LoginViewModel: ViewModelProtocol {
             state.password = password
             
         case .login:        // 키체인에 저장된 값과 입력값이 다를 경우 로그인 실패
-            state.isLoginSuccess = (userEmail == state.email && userPassword == state.password) ? KeychainService.save(service: KeychainConstants.service, account: KeychainConstants.emailAccount, value: state.email) && KeychainService.save(service: KeychainConstants.service, account: KeychainConstants.passwordAccount, value: state.password) : false
+            state.isLoginSuccess = if (userEmail == state.email && userPassword == state.password) {
+                KeychainService.save(
+                    service: KeychainConstants.service,
+                    account: KeychainConstants.emailAccount,
+                    value: state.email
+                ) && KeychainService.save(
+                    service: KeychainConstants.service,
+                    account: KeychainConstants.passwordAccount,
+                    value: state.password)
+            } else {
+                false
+            }
             
             if !state.isLoginSuccess {
                 state.email = ""
@@ -66,7 +77,7 @@ class LoginViewModel: ViewModelProtocol {
     private func validateEmail() {
         if state.email.isEmpty {
             state.emailError = "이메일을 입력해주세요."
-        } else if SignUpViewModel().isValidEmail(state.email) {
+        } else if Validator.isValidEmail(state.email) {
             state.emailError = nil
         } else {
             state.emailError = "올바른 이메일 형식이 아닙니다."

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewController.swift
@@ -112,30 +112,26 @@ class SignUpViewController: UIViewController {
 
 extension SignUpViewController: UITextFieldDelegate {
     
+    // 키보드 done 버튼 누를 때 다음 텍스트 필드로 이동
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if textField == signUpView.emailInput.textField {
+            signUpView.passwordInput.textField.becomeFirstResponder()
+        } else if textField == signUpView.passwordInput.textField {
+            signUpView.confirmPasswordInput.textField.becomeFirstResponder()
+        } else if textField == signUpView.confirmPasswordInput.textField {
+            signUpView.confirmPasswordInput.textField.resignFirstResponder()
+        }
+        return true
+    }
+    
     // 텍스트 필드 포커스 진입 시 placeholder 위로 이동
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        UIView.animate(withDuration: 0.25) {
-            guard let (placeholder, input) = self.textFieldPlaceholderPair(for: textField) else { return }
-            placeholder.snp.updateConstraints {
-                $0.centerY.equalTo(input).offset(-15)
-            }
-            placeholder.font = .systemFont(ofSize: 12)
-            placeholder.superview?.layoutIfNeeded()
-        }
+        updatePlaceholder(for: textField)
     }
     
     // 텍스트 필드 포커스 종료 시 (빈 경우) placeholder 원래 위치로 복귀
     func textFieldDidEndEditing(_ textField: UITextField) {
-        guard textField.text?.isEmpty ?? true else { return }
-        
-        UIView.animate(withDuration: 0.25) {
-            guard let (placeholder, input) = self.textFieldPlaceholderPair(for: textField) else { return }
-            placeholder.snp.updateConstraints {
-                $0.centerY.equalTo(input)
-            }
-            placeholder.font = .systemFont(ofSize: 16)
-            placeholder.superview?.layoutIfNeeded()
-        }
+        updatePlaceholder(for: textField)
     }
     
     // 텍스트필드와 placeholder 쌍을 반환
@@ -149,6 +145,21 @@ extension SignUpViewController: UITextFieldDelegate {
             return (signUpView.confirmPasswordInput.placeholderLabel, signUpView.confirmPasswordInput.textField)
         default:
             return nil
+        }
+    }
+    
+    private func updatePlaceholder(for textField: UITextField) {
+        guard let (placeholder, input) = textFieldPlaceholderPair(for: textField) else { return }
+        
+        let isEmpty = textField.text?.isEmpty ?? true
+        let shouldMoveUp = textField.isFirstResponder || !isEmpty
+        
+        UIView.animate(withDuration: 0.25) {
+            placeholder.snp.updateConstraints {
+                $0.centerY.equalTo(input).offset(shouldMoveUp ? -15 : 0)
+            }
+            placeholder.font = .systemFont(ofSize: shouldMoveUp ? 12 : 16)
+            placeholder.superview?.layoutIfNeeded()
         }
     }
 }

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewController.swift
@@ -134,32 +134,28 @@ extension SignUpViewController: UITextFieldDelegate {
         updatePlaceholder(for: textField)
     }
     
-    // 텍스트필드와 placeholder 쌍을 반환
-    private func textFieldPlaceholderPair(for textField: UITextField) -> (UILabel, UITextField)? {
+    // placeholder 반환
+    private func getPlaceholder(for textField: UITextField) -> UILabel? {
         switch textField {
         case signUpView.emailInput.textField:
-            return (signUpView.emailInput.placeholderLabel, signUpView.emailInput.textField)
+            return signUpView.emailInput.placeholderLabel
         case signUpView.passwordInput.textField:
-            return (signUpView.passwordInput.placeholderLabel, signUpView.passwordInput.textField)
+            return signUpView.passwordInput.placeholderLabel
         case signUpView.confirmPasswordInput.textField:
-            return (signUpView.confirmPasswordInput.placeholderLabel, signUpView.confirmPasswordInput.textField)
+            return signUpView.confirmPasswordInput.placeholderLabel
         default:
             return nil
         }
     }
     
     private func updatePlaceholder(for textField: UITextField) {
-        guard let (placeholder, input) = textFieldPlaceholderPair(for: textField) else { return }
+        guard let placeholder = getPlaceholder(for: textField) else { return }
         
         let isEmpty = textField.text?.isEmpty ?? true
         let shouldMoveUp = textField.isFirstResponder || !isEmpty
         
         UIView.animate(withDuration: 0.25) {
-            placeholder.snp.updateConstraints {
-                $0.centerY.equalTo(input).offset(shouldMoveUp ? -15 : 0)
-            }
-            placeholder.font = .systemFont(ofSize: shouldMoveUp ? 12 : 16)
-            placeholder.superview?.layoutIfNeeded()
+            placeholder.transform = shouldMoveUp ? CGAffineTransform(translationX: -5, y: -15).scaledBy(x: 0.75, y: 0.75) : .identity
         }
     }
 }

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewModel.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class SignUpViewModel {
+class SignUpViewModel: ViewModelProtocol {
     enum Action {
         case emailChanged(String)
         case passwordChanged(String)
@@ -36,7 +36,6 @@ class SignUpViewModel {
     }
     
     var onStateChanged: ((State) -> Void)?
-    private let service = "NBCinema"            // 키체인 서비스 이름
     
     func action(_ action: Action) {
         switch action {
@@ -54,7 +53,7 @@ class SignUpViewModel {
             validateConfirmPassword()
             
         case .signUp:
-            state.isSignedUp = KeychainService.save(service: service, account: state.email, value: state.password)
+            state.isSignedUp = KeychainService.save(service: KeychainConstants.service, account: KeychainConstants.emailAccount, value: state.email) && KeychainService.save(service: KeychainConstants.service, account: KeychainConstants.passwordAccount, value: state.password)
         }
         
         updateSignUpEnabled()
@@ -105,7 +104,7 @@ class SignUpViewModel {
     }
     
     // 이메일 유효성 검사 (~~~@~~~.~~~)
-    private func isValidEmail(_ email: String) -> Bool {
+    func isValidEmail(_ email: String) -> Bool {
         let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
         return NSPredicate(format:"SELF MATCHES %@", emailRegEx).evaluate(with: email)
     }

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewModel.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewModel.swift
@@ -63,7 +63,7 @@ class SignUpViewModel: ViewModelProtocol {
     private func validateEmail() {
         if state.email.isEmpty {
             state.emailError = "이메일을 입력해주세요."
-        } else if isValidEmail(state.email) {
+        } else if Validator.isValidEmail(state.email) {
             state.emailError = nil
         } else {
             state.emailError = "올바른 이메일 형식이 아닙니다."
@@ -74,7 +74,7 @@ class SignUpViewModel: ViewModelProtocol {
     private func validatePassword() {
         if state.password.isEmpty {
             state.passwordError = "비밀번호를 입력해주세요."
-        } else if isValidPassword(state.password) {
+        } else if Validator.isValidPassword(state.password) {
             state.passwordError = nil
         } else {
             state.passwordError = "영문 대소문자/숫자 8자 이상, 특수문자 1개 이상 포함"
@@ -101,17 +101,5 @@ class SignUpViewModel: ViewModelProtocol {
         !state.password.isEmpty &&
         !state.confirmPassword.isEmpty &&
         !state.email.isEmpty
-    }
-    
-    // 이메일 유효성 검사 (~~~@~~~.~~~)
-    func isValidEmail(_ email: String) -> Bool {
-        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
-        return NSPredicate(format:"SELF MATCHES %@", emailRegEx).evaluate(with: email)
-    }
-    
-    // 비멀번호 유효성 검사 (영어 대소문자, 숫자, 특수문자 8자 이상, 특수문자 1개 이상)
-    private func isValidPassword(_ password: String) -> Bool {
-        let regex = #"^(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,}$"#
-        return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: password)
     }
 }

--- a/NBCinema/NBCinema/Presentation/Auth/Validator.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/Validator.swift
@@ -1,0 +1,23 @@
+//
+//  Validator.swift
+//  NBCinema
+//
+//  Created by estelle on 7/20/25.
+//
+
+import Foundation
+
+enum Validator {
+    
+    // 이메일 유효성 검사 (~~~@~~~.~~~)
+    static func isValidEmail(_ email: String) -> Bool {
+        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
+        return NSPredicate(format:"SELF MATCHES %@", emailRegEx).evaluate(with: email)
+    }
+    
+    // 비멀번호 유효성 검사 (영어 대소문자, 숫자, 특수문자 8자 이상, 특수문자 1개 이상)
+    static func isValidPassword(_ password: String) -> Bool {
+        let regex = #"^(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,}$"#
+        return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: password)
+    }
+}

--- a/NBCinema/NBCinema/Presentation/Component/NbcInputField.swift
+++ b/NBCinema/NBCinema/Presentation/Component/NbcInputField.swift
@@ -28,6 +28,7 @@ final class NbcInputField: UIView {
         $0.layer.borderWidth = 1
         $0.layer.borderColor = UIColor.white.cgColor
         $0.autocapitalizationType = .none
+        $0.returnKeyType = .done
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 15, height: $0.frame.height))
         $0.leftViewMode = .always
         $0.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 15, height: $0.frame.height))


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #34 

<br>

### 📽️ Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- 이메일 유효성 검사
- 앱 실행 시 아이디와 비밀번호 자동 입력
- 로그인 성공 시 메인 화면으로 이동
- 로그인 실패(키체인에 저장된 값과 입력값이 다를 경우)  시 실패 알럿
- 키보드의 done 키 클릭 시 다음 텍스트필드로 이동

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

https://github.com/user-attachments/assets/ffdb2a42-02e2-4a87-b7a2-1b79c6a8a390

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
