### PR TITLE
[Feat] #49 이용 약관 동의 구현

### DIFF
--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/AgreeButton.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/AgreeButton.swift
@@ -1,0 +1,71 @@
+//
+//  agreeButton.swift
+//  NBCinema
+//
+//  Created by estelle on 7/21/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class AgreeButton: UIButton {
+    
+    private let iconImageView = UIImageView().then {
+        $0.tintColor = .gray3
+        $0.image = UIImage(systemName: "checkmark.circle")
+    }
+    
+    private let agreeTitleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16, weight: .regular)
+        $0.textColor = .label
+        $0.numberOfLines = 0
+    }
+    
+    var didTap: ((Bool) -> Void)?
+    private(set) var isChecked = false
+    
+    init(title: String) {
+        super.init(frame: .zero)
+        setupUI()
+        agreeTitleLabel.text = title
+        addTarget(self, action: #selector(toggleCheck), for: .touchUpInside)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    @objc private func toggleCheck() {
+        isChecked.toggle()
+        updateIcon()
+        didTap?(isChecked)
+    }
+    
+    func setChecked(_ checked: Bool) {
+        isChecked = checked
+        updateIcon()
+    }
+    
+    private func updateIcon() {
+        let imageName = isChecked ? "checkmark.circle.fill" : "checkmark.circle"
+        iconImageView.image = UIImage(systemName: imageName)
+        iconImageView.tintColor = isChecked ? .nbcMain: .gray3
+    }
+    
+    private func setupUI() {
+        [iconImageView, agreeTitleLabel].forEach { addSubview($0) }
+        
+        iconImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+        
+        agreeTitleLabel.snp.makeConstraints {
+            $0.leading.equalTo(iconImageView.snp.trailing).offset(12)
+            $0.trailing.equalToSuperview()
+            $0.top.bottom.equalToSuperview().inset(8)
+        }
+    }
+}

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/AgreementItem.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/AgreementItem.swift
@@ -1,0 +1,18 @@
+//
+//  AgreementItem.swift
+//  NBCinema
+//
+//  Created by estelle on 7/21/25.
+//
+
+struct AgreementItem {
+    let title: String
+    let isRequired: Bool
+    let button: AgreeButton
+    
+    init(title: String, isRequired: Bool) {
+        self.title = title
+        self.isRequired = isRequired
+        self.button = AgreeButton(title: title)
+    }
+}

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/SignUpViewController.swift
@@ -57,7 +57,11 @@ class SignUpViewController: UIViewController {
     private func bindViewModel() {
         viewModel.onStateChanged = { [weak self] state in
             if state.isSignedUp {
-                self?.showAlert()
+                let termsVC = TermsViewController()
+                termsVC.onAgreeComplete = { [weak self] in
+                    self?.moveToLoginTapped()
+                }
+                self?.present(termsVC, animated: true)
             }
             
             self?.signUpView.emailInput.setError(state.emailError)
@@ -91,15 +95,6 @@ class SignUpViewController: UIViewController {
     // 회원가입 버튼 클릭 시 호출
     @objc private func signUpTapped() {
         viewModel.action(.signUp)
-    }
-    
-    // 회원가입 완료 시 Alert 표시 후 로그인 화면으로 이동
-    private func showAlert() {
-        let alert = UIAlertController(title: "완료", message: "화원 가입이 완료되었습니다.", preferredStyle: .alert)
-        alert.addAction(.init(title: "확인", style: .default) { [weak self] _ in
-            self?.moveToLoginTapped()
-        })
-        present(alert, animated: true)
     }
     
     // 로그인 화면으로 이동

--- a/NBCinema/NBCinema/Presentation/Auth/SignUp/TermsViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Auth/SignUp/TermsViewController.swift
@@ -1,0 +1,112 @@
+//
+//  TermsViewController.swift
+//  NBCinema
+//
+//  Created by estelle on 7/21/25.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+class TermsViewController: UIViewController {
+    
+    var onAgreeComplete: (() -> Void)?
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "약관에 동의하시면 회원가입이 완료됩니다."
+        $0.font = .systemFont(ofSize: 20, weight: .bold)
+        $0.textAlignment = .left
+        $0.textColor = .label
+    }
+    
+    private lazy var allAgreeButton = AgreeButton(title: "전체 동의")
+    private lazy var agreementItems: [AgreementItem] = [
+        AgreementItem(title: "이용약관 및 개인정보취급방침 (필수)", isRequired: true),
+        AgreementItem(title: "개인정보 제3자 제공 동의 (필수)", isRequired: true),
+        AgreementItem(title: "마케팅 활용 동의 (선택)", isRequired: false)
+    ]
+    
+    private lazy var stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 5
+        $0.alignment = .fill
+        $0.distribution = .equalSpacing
+    }
+    
+    private let confirmButton = NbcButton(title: "동의하고 가입하기")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupLayout()
+        setupSheetStyle()
+        setupBinding()
+    }
+    
+    private func setupSheetStyle() {
+        if let sheet = sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+            sheet.preferredCornerRadius = 20
+        }
+        modalPresentationStyle = .pageSheet
+    }
+    
+    private func setupLayout() {
+        confirmButton.isEnabled = false
+        confirmButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+        [titleLabel, stackView, confirmButton].forEach { view.addSubview($0) }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(40)
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+        
+        // 전체 및 개별 동의 버튼 추가
+        stackView.addArrangedSubview(allAgreeButton)
+        agreementItems.forEach {
+            stackView.addArrangedSubview($0.button)
+        }
+    }
+    
+    private func setupBinding() {
+        allAgreeButton.didTap = { [weak self] isChecked in
+            self?.agreementItems.forEach { $0.button.setChecked(isChecked) }
+            self?.confirmButton.isEnabled = isChecked
+        }
+        
+        agreementItems.forEach { item in
+            item.button.didTap = { [weak self] _ in
+                guard let self = self else { return }
+                
+                let allSelected = agreementItems.allSatisfy { $0.button.isChecked }
+                allAgreeButton.setChecked(allSelected)
+                
+                let requiredChecked = agreementItems.filter { $0.isRequired }.allSatisfy { $0.button.isChecked }
+                confirmButton.isEnabled = requiredChecked
+            }
+        }
+    }
+    
+    // 회원가입 동의 시 Alert 표시 후 로그인 화면으로 이동
+    @objc private func confirmButtonTapped() {
+        let alert = UIAlertController(title: "완료", message: "화원 가입이 완료되었습니다.", preferredStyle: .alert)
+        alert.addAction(.init(title: "확인", style: .default) { [weak self] _ in
+            self?.dismiss(animated: true) {
+                self?.onAgreeComplete?()
+            }
+        })
+        present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #49 

<br>

### 📽️ Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- AgreeButton: 동의 버튼 컴포넌트
- SignUpViewController: 회원가입 페이지에서 회원가입 버튼 클릭 시 약관 동의 모달 띄움
- TermsViewController: 약관 동의 후 가입하기 버튼 클릭 시 로그인 화면으로 이동

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
<img width="300" alt="" src="https://github.com/user-attachments/assets/eb511206-b8e7-4930-bf7a-2d83db02953f" />




<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
