### PR TITLE
[Feat] #57 : 영화 예매 화면 이동 관련 처리

### DIFF
--- a/NBCinema/NBCinema/App/Coordinator/BaseCoordinator.swift
+++ b/NBCinema/NBCinema/App/Coordinator/BaseCoordinator.swift
@@ -55,4 +55,10 @@ class BaseCoordinator: Coordinator {
                 self?.navigationController.present(alert, animated: true)
             }
         }
+
+    func showAnyAlert(_ alert: UIAlertController) {
+        DispatchQueue.main.async { [weak self] in
+            self?.navigationController.present(alert, animated: true)
+        }
+    }
 }

--- a/NBCinema/NBCinema/App/Coordinator/MovieDetailCoordinator.swift
+++ b/NBCinema/NBCinema/App/Coordinator/MovieDetailCoordinator.swift
@@ -39,6 +39,7 @@ class MovieDetailCoordinator: BaseCoordinator {
     
     func showReservation(movieId: Int) {
         let reserveVC = ReserveViewController(id: movieId)
+        reserveVC.coordinator = self
         navigationController.pushViewController(reserveVC, animated: true)
     }
     

--- a/NBCinema/NBCinema/Presentation/MyPage/FavoriteView.swift
+++ b/NBCinema/NBCinema/Presentation/MyPage/FavoriteView.swift
@@ -95,6 +95,10 @@ final class FavoriteView: UIView {
             informStackView.addArrangedSubview($0)
         }
 
+        self.snp.makeConstraints {
+            $0.height.equalTo(130)
+        }
+
         posterImageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.height.equalTo(130)
@@ -116,7 +120,6 @@ final class FavoriteView: UIView {
             $0.top.equalTo(movieTitleLabel.snp.bottom).offset(12)
             $0.leading.equalTo(movieTitleLabel)
             $0.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(12)
         }
     }
 

--- a/NBCinema/NBCinema/Presentation/MyPage/MyPageViewController.swift
+++ b/NBCinema/NBCinema/Presentation/MyPage/MyPageViewController.swift
@@ -29,7 +29,16 @@ class MyPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        myPageView.logoutButton.addTarget(self, action: #selector(logoutTapped), for: .touchUpInside)
+        myPageView.logoutButton.addTarget(self,
+                                          action: #selector(logoutTapped),
+                                          for: .touchUpInside
+        )
+        
+        myPageView.reservationsMoreButton.addTarget(
+            self,
+            action: #selector(reservationMoreTapped),
+            for: .touchUpInside
+        )
         myPageView.favoriteMoreButton.addTarget(self, action: #selector(favoriteMoreTapped), for: .touchUpInside)
         myPageView.favoriteTrashButtonTapped = { [weak self] movieTitle in
             self?.myPageViewModel.action(.deleteFavorite(movieTitle: movieTitle))

--- a/NBCinema/NBCinema/Presentation/MyPage/ReservationView.swift
+++ b/NBCinema/NBCinema/Presentation/MyPage/ReservationView.swift
@@ -81,6 +81,10 @@ class ReservationView: UIView {
             informStackView.addArrangedSubview($0)
         }
 
+        self.snp.makeConstraints {
+            $0.height.equalTo(130)
+        }
+
         posterImageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.height.equalTo(130)
@@ -97,7 +101,6 @@ class ReservationView: UIView {
             $0.top.equalTo(movieTitleLabel.snp.bottom).offset(12)
             $0.leading.equalTo(movieTitleLabel)
             $0.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(12)
         }
     }
 }

--- a/NBCinema/NBCinema/Presentation/Reserve/ReserveView.swift
+++ b/NBCinema/NBCinema/Presentation/Reserve/ReserveView.swift
@@ -503,7 +503,7 @@ final class ReserveView: UIView {
         result += "영화 제목 : \(movieTitleLabel.text ?? "")\n"
         result += "예매 일시 : \(reservationTime.toMonthDayString())\n"
         result += "인원 : 청소년 \(youthCount)인, 성인 \(adultCount)인\n"
-        result += "가격 : \(amount) 원"
+        result += "가격 : \(amount.toCommaString()) 원"
 
         return result
     }

--- a/NBCinema/NBCinema/Presentation/Reserve/ReserveView.swift
+++ b/NBCinema/NBCinema/Presentation/Reserve/ReserveView.swift
@@ -503,7 +503,7 @@ final class ReserveView: UIView {
         result += "영화 제목 : \(movieTitleLabel.text ?? "")\n"
         result += "예매 일시 : \(reservationTime.toMonthDayString())\n"
         result += "인원 : 청소년 \(youthCount)인, 성인 \(adultCount)인\n"
-        result += "가격 : \(amount)"
+        result += "가격 : \(amount) 원"
 
         return result
     }

--- a/NBCinema/NBCinema/Presentation/Reserve/ReserveView.swift
+++ b/NBCinema/NBCinema/Presentation/Reserve/ReserveView.swift
@@ -18,7 +18,7 @@ final class ReserveView: UIView {
 
     // MARK: - UI Components
 
-    private let headerView = HeaderView(.sub("예매하기"))
+    let headerView = HeaderView(.sub("예매하기"))
 
     private let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
@@ -491,5 +491,20 @@ final class ReserveView: UIView {
         )
 
         delegate?.reserveButtonTapped(inform: inform)
+    }
+
+    func getMovieInfoString() -> String {
+        let calendar = Calendar.current
+        let day = calendar.startOfDay(for: selectedDate ?? Date())
+        let reservationTime = calendar
+            .date(byAdding: selectedTime ?? DateComponents(), to: day) ?? Date()
+        var result = ""
+
+        result += "영화 제목 : \(movieTitleLabel.text ?? "")\n"
+        result += "예매 일시 : \(reservationTime.toMonthDayString())\n"
+        result += "인원 : 청소년 \(youthCount)인, 성인 \(adultCount)인\n"
+        result += "가격 : \(amount)"
+
+        return result
     }
 }

--- a/NBCinema/NBCinema/Presentation/Reserve/ReserveViewController.swift
+++ b/NBCinema/NBCinema/Presentation/Reserve/ReserveViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class ReserveViewController: UIViewController {
-    //weak var coordinator: ReserveCoodinator?
+    weak var coordinator: BaseCoordinator?
     private let reserveView = ReserveView()
     private let reserveViewModel = ReserveViewModel(
         movieService: NetworkMovieRepository(),
@@ -34,10 +34,24 @@ class ReserveViewController: UIViewController {
 
     override func viewDidLoad() {
         self.navigationController?.isNavigationBarHidden = true
-        tabBarController?.tabBar.isHidden = true
         bindingData()
         reserveViewModel.action(.fetchData(id: id))
         reserveView.delegate = self
+        reserveView.headerView.backButton.addTarget(self,
+                                                    action: #selector(backButtonTapped),
+                                                    for: .touchUpInside
+        )
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        tabBarController?.tabBar.isHidden = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        tabBarController?.tabBar.isHidden = false
     }
 
     private func bindingData() {
@@ -52,7 +66,23 @@ class ReserveViewController: UIViewController {
 
 extension ReserveViewController: ReserveViewDelegate {
     func reserveButtonTapped(inform: UserChoiceInform) {
-        reserveViewModel.action(.saveData(inform))
+        let alertMessage = reserveView.getMovieInfoString() + "\n\n결제하겠습니까?"
+        let alert = UIAlertController(title: "결제 확인", message: alertMessage, preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "예", style: .default) { [weak self] action in
+            self?.reserveViewModel.action(.saveData(inform))
+            self?.coordinator?.navigationController.popViewController(animated: true)
+        }
+        let cancelAction = UIAlertAction(title: "아니요", style: .cancel) { action in
+
+        }
+        alert.addAction(confirmAction)
+        alert.addAction(cancelAction)
+
+        coordinator?.showAnyAlert(alert)
+    }
+
+    @objc func backButtonTapped() {
+        coordinator?.navigationController.popViewController(animated: true)
     }
 }
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #57

<br>

### 📽️ Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

영화 예매 화면에서 결제 완료, 뒤로가기 버튼에 대한 화면 이동처리를 했습니다.

예매 내역, 찜한 영화 목록 들이 기대하던 것보다 높이가 작은걸 확인하여,
수정하였습니다.

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-07-22 at 10 01 41" src="https://github.com/user-attachments/assets/6a4a5c18-11b4-41bd-8890-5ea9f177cf76" />
<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-07-22 at 09 53 25" src="https://github.com/user-attachments/assets/a5377f16-ce20-49ab-9dba-b6938d45fdd8" />

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
